### PR TITLE
Enclose ssh_pub_key in quotes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   ssh_pub_key = File.readlines("#{Dir.home}/.ssh/id_rsa.pub").first.strip
   config.vm.provision 'shell', inline: 'mkdir -p /root/.ssh'
-  config.vm.provision 'shell', inline: "echo #{ssh_pub_key} >> /root/.ssh/authorized_keys"
-  config.vm.provision 'shell', inline: "echo #{ssh_pub_key} >> /home/vagrant/.ssh/authorized_keys", privileged: false
+  config.vm.provision 'shell', inline: "echo '#{ssh_pub_key}' >> /root/.ssh/authorized_keys"
+  config.vm.provision 'shell', inline: "echo '#{ssh_pub_key}' >> /home/vagrant/.ssh/authorized_keys", privileged: false
 end


### PR DESCRIPTION
This should fix key insertion for SSH keys with `<` and `>` in the comment section, e.h.:

```
ssh-rsa AAA.... John Doe <johndoe@email.com>
```

Without quotes, provisioning was crashing because `<` and `>` were interpreted as input/output redirection.